### PR TITLE
Fix for glove.840B.300d.txt valueerror could not convert string to float

### DIFF
--- a/Different Embeddings + Cosine Similarity + HeatMap illustration.ipynb
+++ b/Different Embeddings + Cosine Similarity + HeatMap illustration.ipynb
@@ -102,7 +102,8 @@
     "        content = f.readlines()\n",
     "    model = {}\n",
     "    for line in content:\n",
-    "        splitLine = line.split()\n",
+    "        #splitLine = line.split()\n",
+    "        splitLine = line.strip().split(' ')\n",
     "        word = splitLine[0]\n",
     "        embedding = np.array([float(val) for val in splitLine[1:]])\n",
     "        model[word] = embedding\n",
@@ -221,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
While using glove.840B.300d.txt’, was getting the error 
**`ValueError: could not convert string to float: ‘.’`**
Reason for this is in the embedding file 840B.300d.txt  file, some place there is **'...'**
Used this forum to get the solution
https://forum.opennmt.net/t/how-to-use-glove-pre-trained-embeddings-in-opennmt-py/1011/20